### PR TITLE
Refactor: Implements `ResponseEntity` to `controller`

### DIFF
--- a/src/main/java/com/carloslonghi/ScrumHub/controller/EmployeeController.java
+++ b/src/main/java/com/carloslonghi/ScrumHub/controller/EmployeeController.java
@@ -1,9 +1,10 @@
 package com.carloslonghi.ScrumHub.controller;
 
 import com.carloslonghi.ScrumHub.dto.EmployeeDTO;
-import com.carloslonghi.ScrumHub.model.EmployeeModel;
 import com.carloslonghi.ScrumHub.service.EmployeeService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,27 +17,53 @@ public class EmployeeController {
     private EmployeeService employeeService;
 
     @GetMapping
-    public List<EmployeeDTO> getAll() {
-        return employeeService.getAllEmployees();
+    public ResponseEntity<List<EmployeeDTO>> getAll() {
+        List<EmployeeDTO> employees = employeeService.getAllEmployees();
+        return ResponseEntity.ok(employees);
     }
 
     @PostMapping
-    public EmployeeDTO create(@RequestBody EmployeeDTO employee) {
-        return employeeService.createEmployee(employee);
+    public ResponseEntity<String> create(@RequestBody EmployeeDTO employee) {
+        EmployeeDTO employeeCreated = employeeService.createEmployee(employee);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body("Funcionário \"" + employeeCreated.getName() + "\" cadastrado com sucesso");
     }
 
     @GetMapping("/{id}")
-    public EmployeeDTO getById(@PathVariable Long id) {
-        return employeeService.getEmployeeById(id);
+    public ResponseEntity<?> getById(@PathVariable Long id) {
+        EmployeeDTO employeeFound = employeeService.getEmployeeById(id);
+        if (employeeFound != null) {
+            return ResponseEntity.ok(employeeFound);
+        }
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body("Não existe funcionário com ID \"" + id + "\"");
     }
 
     @PutMapping("/{id}")
-    public EmployeeDTO updateById(@PathVariable Long id, @RequestBody EmployeeDTO employee) {
-        return employeeService.updateById(id, employee);
+    public ResponseEntity<String> updateById(@PathVariable Long id, @RequestBody EmployeeDTO employee) {
+        EmployeeDTO employeeFound = employeeService.getEmployeeById(id);
+        if (employeeFound != null) {
+            EmployeeDTO employeeUpdated = employeeService.updateById(id, employee);
+            return ResponseEntity
+                    .ok("Funcionário \"" + employeeUpdated.getName() + "\" atualizado com sucesso");
+        }
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body("Não existe funcionário com ID \"" + id + "\"");
     }
 
     @DeleteMapping("/{id}")
-    public void deleteById(@PathVariable Long id) {
-        employeeService.deleteEmployeeById(id);
+    public ResponseEntity<String> deleteById(@PathVariable Long id) {
+        EmployeeDTO employeeFound = employeeService.getEmployeeById(id);
+        if (employeeFound != null) {
+            employeeService.deleteEmployeeById(id);
+            return ResponseEntity
+                    .ok("Funcionário \"" + employeeFound.getName() + "\" deletado com sucesso");
+        }
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body("Não existe funcionário com ID \"" + id + "\"");
     }
 }

--- a/src/main/java/com/carloslonghi/ScrumHub/controller/TaskController.java
+++ b/src/main/java/com/carloslonghi/ScrumHub/controller/TaskController.java
@@ -31,7 +31,7 @@ public class TaskController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Object> getById(@PathVariable Long id) {
+    public ResponseEntity<?> getById(@PathVariable Long id) {
         TaskDTO taskFound = taskService.getTaskById(id);
         if (taskFound != null) {
             return ResponseEntity.ok(taskFound);

--- a/src/main/java/com/carloslonghi/ScrumHub/controller/TaskController.java
+++ b/src/main/java/com/carloslonghi/ScrumHub/controller/TaskController.java
@@ -1,10 +1,10 @@
 package com.carloslonghi.ScrumHub.controller;
 
 import com.carloslonghi.ScrumHub.dto.TaskDTO;
-import com.carloslonghi.ScrumHub.mapper.TaskMapper;
-import com.carloslonghi.ScrumHub.model.TaskModel;
 import com.carloslonghi.ScrumHub.service.TaskService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,27 +17,51 @@ public class TaskController {
     private TaskService taskService;
 
     @GetMapping
-    public List<TaskDTO> getAll() {
-        return taskService.getAllTasks();
+    public ResponseEntity<List<TaskDTO>> getAll() {
+        List<TaskDTO> tasks = taskService.getAllTasks();
+        return ResponseEntity.ok(tasks);
     }
 
     @PostMapping
-    public TaskDTO create(@RequestBody TaskDTO task) {
-        return taskService.createTask(task);
+    public ResponseEntity<String> create(@RequestBody TaskDTO task) {
+        TaskDTO taskCreated = taskService.createTask(task);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body("Tarefa \"" + taskCreated.getName() + "\" cadastrada com sucesso");
     }
 
     @GetMapping("/{id}")
-    public TaskDTO getById(@PathVariable Long id) {
-        return taskService.getTaskById(id);
+    public ResponseEntity<Object> getById(@PathVariable Long id) {
+        TaskDTO taskFound = taskService.getTaskById(id);
+        if (taskFound != null) {
+            return ResponseEntity.ok(taskFound);
+        }
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body("Não existe tarefa com ID \"" + id + "\"");
     }
 
     @PutMapping("/{id}")
-    public TaskDTO updateById(@PathVariable Long id, @RequestBody TaskDTO task) {
-        return taskService.updateTaskById(id, task);
+    public ResponseEntity<String> updateById(@PathVariable Long id, @RequestBody TaskDTO task) {
+        TaskDTO taskFound = taskService.getTaskById(id);
+        if (taskFound != null) {
+            TaskDTO taskUpdated = taskService.updateTaskById(id, task);
+            return ResponseEntity
+                    .ok("Tarefa \"" + taskUpdated.getName() + "\" atualizada com sucesso");
+        }
+        return ResponseEntity.ok("Não existe tarefa com ID \"" + id + "\"");
     }
 
     @DeleteMapping("/{id}")
-    public void deleteById(@PathVariable Long id) {
-        taskService.deleteTaskById(id);
+    public ResponseEntity<String> deleteById(@PathVariable Long id) {
+        TaskDTO taskFound = taskService.getTaskById(id);
+        if (taskFound != null) {
+            taskService.deleteTaskById(id);
+            return ResponseEntity
+                    .ok("Tarefa \"" + taskFound.getName() + "\" deletada com sucesso");
+        }
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body("Não existe tarefa com ID \"" + id + "\"");
     }
 }


### PR DESCRIPTION
Alterações propostas pelo PR

- Atualiza os métodos dos `controller's`, para retornarem **ResponseEntity** ao invés de objetos diretamente.

Mudanças visam permitir um maior controle sobre os códigos de status HTTP, cabeçalhos e a estrutura das respostas, facilitando a comunicação adequada entre a API e o cliente.