### PR TITLE
Docs: Implements `Swagger`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/carloslonghi/ScrumHub/controller/EmployeeController.java
+++ b/src/main/java/com/carloslonghi/ScrumHub/controller/EmployeeController.java
@@ -1,5 +1,6 @@
 package com.carloslonghi.ScrumHub.controller;
 
+import com.carloslonghi.ScrumHub.docs.EmployeeControllerDocs;
 import com.carloslonghi.ScrumHub.dto.EmployeeDTO;
 import com.carloslonghi.ScrumHub.service.EmployeeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,17 +12,19 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/employee")
-public class EmployeeController {
+public class EmployeeController implements EmployeeControllerDocs {
 
     @Autowired
     private EmployeeService employeeService;
 
+    @Override
     @GetMapping
     public ResponseEntity<List<EmployeeDTO>> getAll() {
         List<EmployeeDTO> employees = employeeService.getAllEmployees();
         return ResponseEntity.ok(employees);
     }
 
+    @Override
     @PostMapping
     public ResponseEntity<String> create(@RequestBody EmployeeDTO employee) {
         EmployeeDTO employeeCreated = employeeService.createEmployee(employee);
@@ -30,6 +33,7 @@ public class EmployeeController {
                 .body("Funcionário \"" + employeeCreated.getName() + "\" cadastrado com sucesso");
     }
 
+    @Override
     @GetMapping("/{id}")
     public ResponseEntity<?> getById(@PathVariable Long id) {
         EmployeeDTO employeeFound = employeeService.getEmployeeById(id);
@@ -41,6 +45,7 @@ public class EmployeeController {
                 .body("Não existe funcionário com ID \"" + id + "\"");
     }
 
+    @Override
     @PutMapping("/{id}")
     public ResponseEntity<String> updateById(@PathVariable Long id, @RequestBody EmployeeDTO employee) {
         EmployeeDTO employeeFound = employeeService.getEmployeeById(id);
@@ -54,6 +59,7 @@ public class EmployeeController {
                 .body("Não existe funcionário com ID \"" + id + "\"");
     }
 
+    @Override
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteById(@PathVariable Long id) {
         EmployeeDTO employeeFound = employeeService.getEmployeeById(id);

--- a/src/main/java/com/carloslonghi/ScrumHub/controller/TaskController.java
+++ b/src/main/java/com/carloslonghi/ScrumHub/controller/TaskController.java
@@ -49,7 +49,8 @@ public class TaskController {
             return ResponseEntity
                     .ok("Tarefa \"" + taskUpdated.getName() + "\" atualizada com sucesso");
         }
-        return ResponseEntity.ok("Não existe tarefa com ID \"" + id + "\"");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("Não existe tarefa com ID \"" + id + "\"");
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/carloslonghi/ScrumHub/controller/TaskController.java
+++ b/src/main/java/com/carloslonghi/ScrumHub/controller/TaskController.java
@@ -1,5 +1,6 @@
 package com.carloslonghi.ScrumHub.controller;
 
+import com.carloslonghi.ScrumHub.docs.TaskControllerDocs;
 import com.carloslonghi.ScrumHub.dto.TaskDTO;
 import com.carloslonghi.ScrumHub.service.TaskService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,17 +12,19 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/task")
-public class TaskController {
+public class TaskController implements TaskControllerDocs {
 
     @Autowired // Injetando a dependencia service
     private TaskService taskService;
 
+    @Override
     @GetMapping
     public ResponseEntity<List<TaskDTO>> getAll() {
         List<TaskDTO> tasks = taskService.getAllTasks();
         return ResponseEntity.ok(tasks);
     }
 
+    @Override
     @PostMapping
     public ResponseEntity<String> create(@RequestBody TaskDTO task) {
         TaskDTO taskCreated = taskService.createTask(task);
@@ -30,6 +33,7 @@ public class TaskController {
                 .body("Tarefa \"" + taskCreated.getName() + "\" cadastrada com sucesso");
     }
 
+    @Override
     @GetMapping("/{id}")
     public ResponseEntity<?> getById(@PathVariable Long id) {
         TaskDTO taskFound = taskService.getTaskById(id);
@@ -41,6 +45,7 @@ public class TaskController {
                 .body("Não existe tarefa com ID \"" + id + "\"");
     }
 
+    @Override
     @PutMapping("/{id}")
     public ResponseEntity<String> updateById(@PathVariable Long id, @RequestBody TaskDTO task) {
         TaskDTO taskFound = taskService.getTaskById(id);
@@ -53,6 +58,7 @@ public class TaskController {
                 .body("Não existe tarefa com ID \"" + id + "\"");
     }
 
+    @Override
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteById(@PathVariable Long id) {
         TaskDTO taskFound = taskService.getTaskById(id);

--- a/src/main/java/com/carloslonghi/ScrumHub/docs/EmployeeControllerDocs.java
+++ b/src/main/java/com/carloslonghi/ScrumHub/docs/EmployeeControllerDocs.java
@@ -1,0 +1,37 @@
+package com.carloslonghi.ScrumHub.docs;
+
+import com.carloslonghi.ScrumHub.dto.EmployeeDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Funcionários", description = "Operações relacionadas aos Funcionários")
+public interface EmployeeControllerDocs {
+
+    @Operation(summary = "Listar Funcionários", description = "Rota para LISTAR os funcionários cadastrados, assim como suas respectivas tarefas.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Funcionários listados com sucesso")
+    })
+    ResponseEntity<List<EmployeeDTO>> getAll();
+
+    @Operation(summary = "Cadastrar Funcionário", description = "Rota para CRIAR um novo funcionário")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Funcionário cadastrado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Erro no cadastro do Funcionário")
+    })
+    ResponseEntity<String> create(@RequestBody EmployeeDTO employee);
+
+    @Operation(summary = "Buscar Funcionário por ID", description = "Rota para BUSCAR funcionário cadastrado por ID")
+    ResponseEntity<?> getById(@PathVariable Long id);
+
+    @Operation(summary = "Atualizar Funcionário por ID", description = "Rota para ATUALIZAR funcionário cadastrado por ID")
+    ResponseEntity<String> updateById(@PathVariable Long id, @RequestBody EmployeeDTO employee);
+
+    @Operation(summary = "Deletar Funcionário por ID", description = "Rota para DELETAR funcionário cadastrado por ID")
+    ResponseEntity<String> deleteById(@PathVariable Long id);
+}

--- a/src/main/java/com/carloslonghi/ScrumHub/docs/TaskControllerDocs.java
+++ b/src/main/java/com/carloslonghi/ScrumHub/docs/TaskControllerDocs.java
@@ -1,0 +1,49 @@
+package com.carloslonghi.ScrumHub.docs;
+
+import com.carloslonghi.ScrumHub.dto.TaskDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Tarefas", description = "Operações relacionadas às Tarefas")
+public interface TaskControllerDocs {
+
+    @Operation(summary = "Listar Tarefas", description = "Rota para LISTAR todas as tarefas cadastradas.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tarefas listadas com sucesso")
+    })
+    ResponseEntity<List<TaskDTO>> getAll();
+
+    @Operation(summary = "Cadastrar Tarefa", description = "Rota para CRIAR uma nova tarefa.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Tarefa cadastrada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Erro no cadastro da tarefa")
+    })
+    ResponseEntity<String> create(@RequestBody TaskDTO task);
+
+    @Operation(summary = "Buscar Tarefa por ID", description = "Rota para BUSCAR uma tarefa por ID.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tarefa encontrada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Tarefa não encontrada")
+    })
+    ResponseEntity<?> getById(@PathVariable Long id);
+
+    @Operation(summary = "Atualizar Tarefa por ID", description = "Rota para ATUALIZAR uma tarefa existente pelo ID.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tarefa atualizada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Tarefa não encontrada")
+    })
+    ResponseEntity<String> updateById(@PathVariable Long id, @RequestBody TaskDTO task);
+
+    @Operation(summary = "Deletar Tarefa por ID", description = "Rota para DELETAR uma tarefa existente pelo ID.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tarefa deletada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Tarefa não encontrada")
+    })
+    ResponseEntity<String> deleteById(@PathVariable Long id);
+}


### PR DESCRIPTION
Alterações propostas pelo PR

Este PR implementa **Swagger/OpenAPI** organizando e separarando as anotações de documentação dos controllers, mantendo uma melhor legibilidade e manutenção do código.

✅ Alterações realizadas:
- Cria interfaces de documentação (ControllerDocs) para os controllers existentes (TaskController, EmployeeController), contendo anotações como:

  - @ Operation para sumarização dos endpoints.

  - @ ApiResponses para detalhamento dos códigos de resposta da API.

  - @ Tag para agrupamento dos endpoints por domínio no Swagger UI.

  - Facilita a manutenção e evolução da documentação da API.

Mudanças visam permitir uma maior organização de código, tornando a camada de controller mais limpa e objetiva, separando responsabilidades (lógica de rota vs. documentação).